### PR TITLE
Add support for non multiarch systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ set(LIBVER  "${MAJOR_VERSION}.${API_COMPAT}.${MINOR_VERSION}")
 
 # determine target architecture
 execute_process(COMMAND ${CMAKE_C_COMPILER} -print-multiarch OUTPUT_VARIABLE CC_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(CC_ARCH STREQUAL "")
+  message(STATUS "CC_ARCH unset, guesing using uname -p")
+  execute_process(COMMAND uname -p OUTPUT_VARIABLE CC_ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 if(CC_ARCH MATCHES "i386")
     message(STATUS "Building for i386")
     set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "i386")


### PR DESCRIPTION
In non-multiarch systems (for example RedHat-based such as Fedora), gcc -print-multiarch returns an empty string.
So if an empty string is detected, then it is replaced by the results of uname -p.
This workaround works if the target architecture is the same as the host one.