### PR TITLE
install binaries (TARGETS) in proper directory (bin)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,9 @@ endif()
 
 add_definitions(-Wall -g)
 
+set(XTRXDSP_RUNTIME_DIR      bin)
 set(XTRXDSP_LIBRARY_DIR      lib${LIB_SUFFIX})
 set(XTRXDSP_INCLUDE_DIR      include)
-set(XTRXDSP_UTILS_DIR        ${XTRXDSP_LIBRARY_DIR}/xtrxdsp)
 
 CONFIGURE_FILE(
     ${CMAKE_CURRENT_SOURCE_DIR}/libxtrxdsp.pc.in
@@ -101,7 +101,7 @@ add_subdirectory(tests)
 ########################################################################
 # install headers & targets
 ########################################################################
-install(TARGETS xtrxdsp DESTINATION ${XTRXDSP_LIBRARY_DIR})
+install(TARGETS xtrxdsp DESTINATION ${XTRXDSP_RUNTIME_DIR})
 
 install(FILES
     xtrxdsp.h xtrxdsp_config.h xtrxdsp_filters.h xtrxdsp_fft.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,4 +11,4 @@ add_executable(test_filter test_filter.c)
 target_link_libraries(test_filter xtrxdsp m ${SYSTEM_LIBS})
 
 
-install(TARGETS test_filter test_xtrxdsp_sc32i_iq16 DESTINATION ${XTRXDSP_UTILS_DIR})
+install(TARGETS test_filter test_xtrxdsp_sc32i_iq16 DESTINATION ${XTRXDSP_RUNTIME_DIR})


### PR DESCRIPTION
with Linux system, binaries are usually installed in bin directory.