### PR TITLE
32-bit i386 doesn't have SSE2 nor AVX

### DIFF
--- a/xtrxdsp.c
+++ b/xtrxdsp.c
@@ -179,7 +179,7 @@ void xtrxdsp_init(void)
 #define CHECK_FUNC_SSE2(func)
 #endif
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__)
 
 static func_xtrxdsp_iq16_sc32_t resolve_xtrxdsp_iq16_sc32(void)
 {


### PR DESCRIPTION
Fixes compilation on Debian i386:

/usr/bin/cc -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -Wl,-z,relro -rdynamic CMakeFiles/test_xtrxdsp_sc32i_iq16.dir/test_xtrxdsp_sc32i_iq16.c.o  -o test_xtrxdsp_sc32i_iq16  -Wl,-rpath,/<<PKGBUILDDIR>>/obj-i686-linux-gnu: ../libxtrxdsp.so.0.0.1 -lrt -ldl -lpthread
/usr/bin/ld: ../libxtrxdsp.so.0.0.1: undefined reference to `xtrxdsp_iq16_ic16i_avx'
/usr/bin/ld: ../libxtrxdsp.so.0.0.1: undefined reference to `xtrxdsp_iq16_ic16i_sse2'
/usr/bin/ld: ../libxtrxdsp.so.0.0.1: undefined reference to `xtrxdsp_iq16_conv64_sse2'
/usr/bin/ld: ../libxtrxdsp.so.0.0.1: undefined reference to `xtrxdsp_iq8_sc32_avx'
/usr/bin/ld: ../libxtrxdsp.so.0.0.1: undefined reference to `xtrxdsp_iq16_sc32i_avx'
...